### PR TITLE
layout: make each entry take up 25% of the width (close #45)

### DIFF
--- a/layouts/partials/shared/summary-people.html
+++ b/layouts/partials/shared/summary-people.html
@@ -2,7 +2,7 @@
 {{ $section := $page.CurrentSection }}     <!--save branch section-->
 {{ $root := .Scratch.Get "$root" }}        <!--save root section-->
 
-<article class="w-100 w-50-m w-third-l mb4 pb4 bb bw1 bw0-ns pb0-ns">
+<article class="w-100 w-50-m w-25-ns mb4 pb4 bb bw1 bw0-ns pb0-ns">
   <!--if show_post_thumbnail is TRUE in root-->
   {{ if $root.Params.show_post_thumbnail }}
   <div class="ph0 ph2-m ph3-l">


### PR DESCRIPTION
Adjust the grid layout for People so all team members fit on one line